### PR TITLE
Update sv_hooks.lua

### DIFF
--- a/upload/gamemodes/clockwork/framework/hooks/sv_hooks.lua
+++ b/upload/gamemodes/clockwork/framework/hooks/sv_hooks.lua
@@ -2428,7 +2428,7 @@ local function PlayerSayFunc(player, text)
 
 		if (Clockwork.command.stored[command] and Clockwork.command.stored[command].arguments < 2
 		and !Clockwork.command.stored[command].optionalArguments) then
-			text = arguments[2] or ""
+			text = string.gsub(string.utf8sub(text, string.len(command) + prefixLength + 2), "\"", "");
 
 			if (text != "") then
 				arguments = {command, text};

--- a/upload/gamemodes/clockwork/framework/hooks/sv_hooks.lua
+++ b/upload/gamemodes/clockwork/framework/hooks/sv_hooks.lua
@@ -2428,7 +2428,7 @@ local function PlayerSayFunc(player, text)
 
 		if (Clockwork.command.stored[command] and Clockwork.command.stored[command].arguments < 2
 		and !Clockwork.command.stored[command].optionalArguments) then
-			text = string.utf8sub(text, string.len(command) + prefixLength + 2);
+			text = arguments[2] or ""
 
 			if (text != "") then
 				arguments = {command, text};


### PR DESCRIPTION
this commit fixes double quotes not escaping on single argument chat commands.

`/charforcegetup "Bot01"` would've failed previously because it would pass `'"Bot01"'` into `Clockwork.player:FindByID()`