### PR TITLE
Fresh little piggy Immortal squeals

### DIFF
--- a/gamemodes/clockwork/framework/items/bases/sh_clothes_base.lua
+++ b/gamemodes/clockwork/framework/items/bases/sh_clothes_base.lua
@@ -451,6 +451,13 @@ local ITEM = item.New(nil, true);
 					if !player:IsNoClipping() and (!player.GetCharmEquipped or !player:GetCharmEquipped("urn_silence")) then
 						local useSound = self("useSound");
 						
+						if self.uniqueID == "darklander_immortal_armor" then	
+							player:EmitSound("piggysqueals/transformation/"..math.random(1, 2)..".mp3");
+							player:Disorient(8)
+							timer.Create( "Squeal", 5.5, 1, function() netstream.Start(player, "Stunned", 3); end )
+							Clockwork.chatBox:AddInTargetRadius(player, "me", "writhes in agony as the sounds of bones snapping and flesh reshaping violently emanate from within their armor! Their cries of pain gradually transform into pig-like grunts, before they squeal out like a fresh little piggy ready for the slaughter!", player:GetPos(), config.Get("talk_radius"):Get() * 2);
+						end
+						
 						if (useSound) then
 							if (type(useSound) == "table") then
 								player:EmitSound(useSound[math.random(1, #useSound)]);

--- a/gamemodes/cwbegotten/plugins/clothes/plugin/items/sh_armors_satanists.lua
+++ b/gamemodes/cwbegotten/plugins/clothes/plugin/items/sh_armors_satanists.lua
@@ -469,11 +469,13 @@ ITEM:Register();
 
 local ITEM = Clockwork.item:New("clothes_base");
 ITEM.name = "Darklander Immortal Armor";
+ITEM.uniqueID = "darklander_immortal_armor"
 ITEM.model = "models/begotten/headgroups_props/darklanderimmortal.mdl"
 ITEM.iconoverride = "materials/begotten/ui/itemicons/darklander_immortal_armor.png"
 ITEM.category = "Armor"
 ITEM.concealsFace = true;
-ITEM.conditionScale = 0.75
+ITEM.conditionScale = 0
+ITEM.permanent = true;
 ITEM.hasHelmet = true;
 ITEM.hitParticle = "MetalSpark";
 ITEM.protection = 85;
@@ -483,6 +485,7 @@ ITEM.type = "plate";
 ITEM.description = "Heavy plate armor of Eastern Nigerii design. It is meant for the infamous Immortals, an elite band of warriors devoted to the Emperor. A dark magic prevents this armor from being worn by anyone not of the bloodline of the King of Kings.";
 ITEM.useSound = "armormovement/body-armor-b4.WAV.mp3";
 ITEM.requiredFactions = {"Children of Satan"};
+ITEM.attributes = {"conditionless", "not_unequippable"};
 ITEM.overlay = "begotten/zomboverlay/new/immortal";
 ITEM.faction = "Children of Satan";
 

--- a/gamemodes/cwbegotten/plugins/crafting/plugin/sh_recipes.lua
+++ b/gamemodes/cwbegotten/plugins/crafting/plugin/sh_recipes.lua
@@ -9253,6 +9253,7 @@ function cwRecipes:ClockworkInitialized()
 		RECIPE.requirements = {
 			["hellforged_steel_ingot"] = {amount = 4},
 			["fine_steel_ingot"] = {amount = 2},
+			["pentagram_catalyst"] = {amount = 1},
 		};
 		RECIPE.result = {
 			["darklander_immortal_armor"] = {amount = 1},

--- a/gamemodes/cwbegotten/plugins/melee/plugin/sv_hooks.lua
+++ b/gamemodes/cwbegotten/plugins/melee/plugin/sv_hooks.lua
@@ -620,7 +620,9 @@ function cwMelee:PlayerStabilityFallover(player, falloverTime, bNoBoogie, bNoTex
 		if player:GetSubfaith() == "Voltism" and cwBeliefs and (player:HasBelief("the_storm") or player:HasBelief("the_paradox_riddle_equation")) then
 			player:EmitSound(voltistSounds["pain"][math.random(1, #voltistSounds["pain"])], 90, 150);
 		else
-			if (faction == "Gatekeeper" or faction == "Pope Adyssa's Gatekeepers") then
+			if player:GetModel() == "models/begotten/satanists/darklanderimmortal.mdl" then
+				player:EmitSound("piggysqueals/death/"..math.random(1, 3)..".ogg", 90, pitch)
+			elseif (faction == "Gatekeeper" or faction == "Pope Adyssa's Gatekeepers") then
 				if (gender == "his") then
 					player:EmitSound("voice/man2/man2_stun0"..math.random(1, 4)..".wav", 90, pitch)
 				else
@@ -930,6 +932,9 @@ function cwMelee:PlayerPlayPainSound(player, gender, damageInfo, hitGroup)
 			if player:GetCharacterData("isThrall") then
 				player:EmitSound("apocalypse/screams/far"..math.random(1,6)..".wav", 90, pitch);
 				player.nextPainSound = CurTime()+0.5;
+			elseif player:GetModel() == "models/begotten/satanists/darklanderimmortal.mdl" then
+				player:EmitSound("piggysqueals/pain/"..math.random(1, 5)..".ogg", 90, pitch)
+				player.nextPainSound = CurTime()+1;
 			elseif faction == "Gatekeeper" or faction == "Pope Adyssa's Gatekeepers" then
 				if gender == "Male" then
 					player:EmitSound("voice/man2/man2_pain0"..math.random(1, 6)..".wav", 90, pitch)
@@ -1012,6 +1017,8 @@ function GM:PlayerPlayDeathSound(player, gender)
 		if player:GetCharacterData("isThrall") then
 			player:EmitSound("apocalypse/screams/far"..math.random(1,6)..".wav", 90, pitch);
 			player.nextPainSound = CurTime()+0.5;
+		elseif player:GetModel() == "models/begotten/satanists/darklanderimmortal.mdl" then
+			player:EmitSound("piggysqueals/death/"..math.random(4, 6)..".ogg", 90, pitch)
 		elseif faction == "Gatekeeper" or faction == "Pope Adyssa's Gatekeepers" then
 			if gender == "Male" then
 				player:EmitSound("voice/man2/man2_death0"..math.random(1, 9)..".wav", 90, pitch)

--- a/gamemodes/cwbegotten/schema/sh_coms.lua
+++ b/gamemodes/cwbegotten/schema/sh_coms.lua
@@ -1865,7 +1865,9 @@ local COMMAND = Clockwork.command:New("Proclaim");
 				if player.victim and IsValid(player.victim) then
 					Clockwork.chatBox:AddInRadius(player.victim, "proclaim", text, player.victim:GetPos(), config.Get("talk_radius"):Get() * 4);
 					
-					if player.victim:GetSubfaith() == "Voltism" then
+					if player.victim:GetModel() == "models/begotten/satanists/darklanderimmortal.mdl" then
+						player.victim:EmitSound("piggysqueals/yell/wretch_tunnels_amb_alert_0"..math.random(1, 3)..".ogg", 90, math.random(95, 110))
+					elseif player.victim:GetSubfaith() == "Voltism" then
 						if cwBeliefs and (player.victim:HasBelief("the_storm") or player.victim:HasBelief("the_paradox_riddle_equation")) then
 							if !Clockwork.player:HasFlags(player.victim, "T") then
 								player.victim:EmitSound(voltistSounds[math.random(1, #voltistSounds)], 90, 150);
@@ -1881,7 +1883,9 @@ local COMMAND = Clockwork.command:New("Proclaim");
 				else
 					Clockwork.chatBox:AddInRadius(player, "proclaim", text, player:GetPos(), config.Get("talk_radius"):Get() * 4);
 					
-					if player:GetSubfaith() == "Voltism" then
+					if player:GetModel() == "models/begotten/satanists/darklanderimmortal.mdl" then
+						player:EmitSound("piggysqueals/yell/wretch_tunnels_amb_alert_0"..math.random(1, 3)..".ogg", 90, math.random(95, 110))
+					elseif player:GetSubfaith() == "Voltism" then
 						if cwBeliefs and (player:HasBelief("the_storm") or player:HasBelief("the_paradox_riddle_equation")) then
 							if !Clockwork.player:HasFlags(player, "T") then
 								player:EmitSound(voltistSounds[math.random(1, #voltistSounds)], 90, 150);

--- a/gamemodes/cwbegotten/schema/sv_hooks.lua
+++ b/gamemodes/cwbegotten/schema/sv_hooks.lua
@@ -1292,7 +1292,9 @@ local voltistSounds = {"npc/scanner/combat_scan4.wav", "npc/scanner/combat_scan5
 local voltistYellSounds = {"npc/scanner/scanner_siren2.wav", "npc/scanner/scanner_pain2.wav", "npc/stalker/go_alert2.wav"};
 
 function Schema:PlayerSayICEmitSound(player)
-	if player:GetSubfaith() == "Voltism" then
+	if player:GetModel() == "models/begotten/satanists/darklanderimmortal.mdl" then
+		player:EmitSound("piggysqueals/talk/wretch_tunnels_amb_idle_0"..math.random(1, 5)..".ogg", 90, math.random(95, 110))
+	elseif player:GetSubfaith() == "Voltism" then
 		if cwBeliefs and (player:HasBelief("the_storm") or player:HasBelief("the_paradox_riddle_equation")) then
 			if !Clockwork.player:HasFlags(player, "T") then
 				player:EmitSound(voltistSounds[math.random(1, #voltistSounds)], 90, 150);
@@ -1302,7 +1304,9 @@ function Schema:PlayerSayICEmitSound(player)
 end
 
 function Schema:PlayerYellEmitSound(player)
-	if player:GetSubfaith() == "Voltism" then
+	if player:GetModel() == "models/begotten/satanists/darklanderimmortal.mdl" then
+		player:EmitSound("piggysqueals/yell/wretch_tunnels_amb_alert_0"..math.random(1, 3)..".ogg", 90, math.random(95, 110))
+	elseif player:GetSubfaith() == "Voltism" then
 		if cwBeliefs and (player:HasBelief("the_storm") or player:HasBelief("the_paradox_riddle_equation")) then
 			if !Clockwork.player:HasFlags(player, "T") then
 				player:EmitSound(voltistYellSounds[math.random(1, #voltistYellSounds)], 90, 150);


### PR DESCRIPTION
- Darklander Immortal Armor is now unequipable and conditionless, but it's recipe cost is increased by a pentagram catalyst.
- Wearing Immortal Armor now plays loud pig squeals when getting hurt, getting knocked over from stability or dying. Pig-like grunts play when talking, yelling and proclaiming. A special sequence plays when Immortal Armor is put on.