### PR TITLE
Warcry, Warhorn and Death Whistle Sound Radius Fix

### DIFF
--- a/gamemodes/cwbegotten/plugins/beliefs/plugin/cl_hooks.lua
+++ b/gamemodes/cwbegotten/plugins/beliefs/plugin/cl_hooks.lua
@@ -404,3 +404,7 @@ netstream.Hook("UpgradedWarcry", function(data)
 		end);
 	--end
 end);
+
+netstream.Hook("WarcrySound", function(speaker, warcrySound, warcryPitch)
+	speaker:EmitSound(warcrySound, 100, warcryPitch)
+end)

--- a/gamemodes/cwbegotten/plugins/beliefs/plugin/sh_plugin.lua
+++ b/gamemodes/cwbegotten/plugins/beliefs/plugin/sh_plugin.lua
@@ -1344,12 +1344,16 @@ local COMMAND = Clockwork.command:New("Warcry");
 						end
 					end
 
-					player:EmitSound((Clockwork.player:HasFlags(player, "~") and "warcries/warcry"..math.random(1, 16)..".mp3" or "glazecries/hillcry_"..math.random(1, 20)..".wav"), 100, math.random(90, 105));
-
-					Clockwork.chatBox:AddInTargetRadius(player, "me", "lets out a booming shout!", playerPos, radius);
+					Clockwork.chatBox:AddInTargetRadius(player, "me", "lets out a booming shout!", playerPos, radius, {
+						warcrySound = (Clockwork.player:HasFlags(player, "~") and "warcries/warcry"..math.random(1, 16)..".mp3" or "glazecries/hillcry_"..math.random(1, 20)..".wav"),
+						warcryPitch = math.random(90, 105)
+					});
 				elseif (subfaction == "Low Ministry") then
 					player:EmitSound("lmcries/lm_cry" .. math.random(1,19) .. ".mp3", 100, math.random(90, 105));
-					Clockwork.chatBox:AddInTargetRadius(player, "me", "lets out a withering scream!", playerPos, radius);
+					Clockwork.chatBox:AddInTargetRadius(player, "me", "lets out a withering scream!", playerPos, radius, {
+						warcrySound = (Clockwork.player:HasFlags(player, "~") and "warcries/warcry"..math.random(1, 16)..".mp3" or "glazecries/hillcry_"..math.random(1, 20)..".wav"),
+						warcryPitch = math.random(90, 105)
+					});
 				elseif subfaction == "Clan Grock" then
 					local clothesItem = player:GetClothesEquipped()
 					
@@ -1357,13 +1361,17 @@ local COMMAND = Clockwork.command:New("Warcry");
 						player:HandleSanity(-5);
 						local warcrySounds = {"kronos/sawcrazy/random2.wav", "kronos/sawcrazy/random1.wav", "kronos/sawrunner/sawrunner_attack2.wav", "kronos/sawrunner/sawrunner_alert30.wav", "kronos/boss/mace_scream.wav"}
 						local selectedSound = warcrySounds[math.random(#warcrySounds)]
-						player:EmitSound(selectedSound, 100, math.random(60, 75));
-						Clockwork.chatBox:AddInTargetRadius(player, "me", "screams and groans in a mockery of prayer!", playerPos, radius);
+						Clockwork.chatBox:AddInTargetRadius(player, "me", "screams and groans in a mockery of prayer!", playerPos, radius, {
+							warcrySound = selectedSound,
+							warcryPitch = math.random(60, 75)
+						});
 						netstream.Start(player, "UpgradedWarcry", affected_players);
 					else
 						player:HandleStamina(25);
-						player:EmitSound("warcries/grock_warcry"..math.random(1, 11)..".ogg", 100, math.random(60, 75));
-						Clockwork.chatBox:AddInTargetRadius(player, "me", "barbarically shouts out!", playerPos, radius);
+						Clockwork.chatBox:AddInTargetRadius(player, "me", "barbarically shouts out!", playerPos, radius, {
+							warcrySound = "warcries/grock_warcry"..math.random(1, 11)..".ogg",
+							warcryPitch = math.random(60, 75)
+						});
 					end
 				-- Kinisgers can FotF warcry if not disguised as a reaver.
 				elseif faith == "Faith of the Family" then
@@ -1438,13 +1446,17 @@ local COMMAND = Clockwork.command:New("Warcry");
 						netstream.Start(player, "UpgradedWarcry", affected_players);
 					end
 					
-					player:EmitSound(warcrySound, 100, warcryPitch);
-					Clockwork.chatBox:AddInTargetRadius(player, "me", warcryText, playerPos, radius);
+					Clockwork.chatBox:AddInTargetRadius(player, "me", warcryText, playerPos, radius, {
+						warcrySound = warcrySound,
+						warcryPitch = warcryPitch
+					});
 				else
 					player:HandleSanity(-5);
-					player:EmitSound("warcries/twistedwarcry"..math.random(1, 5)..".mp3", 100, math.random(90, 105));
 					
-					Clockwork.chatBox:AddInTargetRadius(player, "me", "lets out a twisted warcry, screaming with the voices of their past victims!", playerPos, radius);
+					Clockwork.chatBox:AddInTargetRadius(player, "me", "lets out a twisted warcry, screaming with the voices of their past victims!", playerPos, radius, {
+						warcrySound = "warcries/twistedwarcry"..math.random(1, 5)..".mp3",
+						warcryPitch = math.random(90, 105)
+					});
 				end
 				
 				if player_has_daring_trout then

--- a/gamemodes/cwbegotten/plugins/beliefs/plugin/sv_hooks.lua
+++ b/gamemodes/cwbegotten/plugins/beliefs/plugin/sv_hooks.lua
@@ -2586,3 +2586,9 @@ function cwBeliefs:ModifyPlayerSpeed(player, infoTable)
 		infoTable.runSpeed = infoTable.runSpeed * 1.15;
 	end
 end
+
+function cwBeliefs:ChatBoxMessageAdded(info)
+	if IsValid(info.speaker) and info.data.warcrySound then
+		netstream.Start(info.listeners, "WarcrySound", info.speaker, info.data.warcrySound, info.data.warcryPitch);
+	end
+end

--- a/gamemodes/cwbegotten/schema/cl_hooks.lua
+++ b/gamemodes/cwbegotten/schema/cl_hooks.lua
@@ -4333,6 +4333,10 @@ netstream.Hook("NPCSpawnESPInfo", function(data)
 	end
 end);
 
+netstream.Hook("WarhornOrDeathWhistleSound", function(speaker, wdwSound, wdwPitch)
+	speaker:EmitSound(wdwSound, wdwPitch)
+end)
+
 -- Save data icon in top right.
 local pentaFade;
 local pentaAlpha = 0;

--- a/gamemodes/cwbegotten/schema/cl_hooks.lua
+++ b/gamemodes/cwbegotten/schema/cl_hooks.lua
@@ -4334,7 +4334,7 @@ netstream.Hook("NPCSpawnESPInfo", function(data)
 end);
 
 netstream.Hook("WarhornOrDeathWhistleSound", function(speaker, wdwSound, wdwPitch)
-	speaker:EmitSound(wdwSound, wdwPitch)
+	speaker:EmitSound(wdwSound, 100, wdwPitch)
 end)
 
 -- Save data icon in top right.

--- a/gamemodes/cwbegotten/schema/items/sh_tools.lua
+++ b/gamemodes/cwbegotten/schema/items/sh_tools.lua
@@ -866,6 +866,8 @@ local ITEM = Clockwork.item:New();
 			
 				if faction == "Gatekeeper" or faction == "Hillkeeper" or faction == "Holy Hierarchy" then
 					if (name == "Sound Attack") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -875,11 +877,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/warhorn3.mp3", 100, math.random(98, 102));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/warhorn3.mp3", math.random(98, 102));
 					elseif (name == "Sound Rally") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -889,11 +895,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/warhorn7.mp3", 100, math.random(98, 102));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/warhorn7.mp3", math.random(98, 102));
 					elseif (name == "Sound Rally - Marching Formation") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -903,11 +913,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/warhorn8.mp3", 100, math.random(98, 102));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/warhorn8.mp3", math.random(98, 102));
 					elseif (name == "Sound Rally - Shieldwall") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -917,11 +931,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/warhorn4.mp3", 100, math.random(98, 102));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/warhorn4.mp3", math.random(98, 102));
 					elseif (name == "Sound Retreat") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -931,13 +949,17 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/warhorn6.mp3", 100, math.random(98, 102));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/warhorn6.mp3", math.random(98, 102));
 					end;
 				elseif faction == "Goreic Warrior" then
 					if (name == "Sound Attack") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -947,11 +969,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/gore_warhorn_attack.mp3", 100, math.random(88, 108));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/gore_warhorn_attack.mp3", math.random(88, 108));
 					elseif (name == "Sound Rally") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -961,11 +987,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/gore_warhorn_rally.mp3", 100, math.random(88, 108));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/gore_warhorn_rally.mp3", math.random(88, 108));
 					elseif (name == "Sound Rally - Marching Formation") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -975,11 +1005,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/gore_warhorn_formation.mp3", 100, math.random(95, 118));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/gore_warhorn_formation.mp3", math.random(95, 118));
 					elseif (name == "Sound Rally - Shieldwall") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -989,11 +1023,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/gore_warhorn_formation.mp3", 100, math.random(77, 86));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/gore_warhorn_formation.mp3", math.random(77, 86));
 					elseif (name == "Sound Retreat") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -1003,10 +1041,12 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." blows their warhorn, but its signal is unknown to you!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
 						
-						player:EmitSound("warhorns/gore_warhorn_retreat.mp3", 100, math.random(88, 108));
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/gore_warhorn_retreat.mp3", math.random(88, 108));
 					end;
  
 				else
@@ -1054,6 +1094,8 @@ local ITEM = Clockwork.item:New();
 				
 				if faction == "Children of Satan" then
 					if (name == "Sound Attack") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -1062,10 +1104,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." sounds a terrifying death whistle!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
-						player:EmitSound("warhorns/deathwhistle"..math.random(1,2)..".mp3", 100, math.random(98, 102));
+
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/deathwhistle"..math.random(1,2)..".mp3", math.random(98, 102));
 					elseif (name == "Sound Rally") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -1075,10 +1122,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." sounds a terrifying death whistle!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
-						player:EmitSound("warhorns/deathwhistle5.mp3", 100, math.random(98, 102));
+
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/deathwhistle5.mp3", math.random(98, 102));
 					elseif (name == "Sound Rally - Marching Formation") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -1088,10 +1140,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." sounds a terrifying death whistle!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
-						player:EmitSound("warhorns/deathwhistle5.mp3", 100, math.random(98, 102));
+
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/deathwhistle5.mp3", math.random(98, 102));
 					elseif (name == "Sound Rally - Shieldwall") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -1101,10 +1158,15 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." sounds a terrifying death whistle!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
-						player:EmitSound("warhorns/deathwhistle5.mp3", 100, math.random(98, 102));
+
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/deathwhistle5.mp3", math.random(98, 102));
 					elseif (name == "Sound Retreat") then
+						local listeners = {};
+
 						for k, v in pairs(ents.FindInSphere(playerPos, radius)) do
 							if v:IsPlayer() then
 								local vFaction = v:GetFaction();
@@ -1113,9 +1175,12 @@ local ITEM = Clockwork.item:New();
 								else
 									Clockwork.chatBox:Add(v, nil, "localevent", player:Name().." sounds a terrifying death whistle!");
 								end
+
+								listeners[#listeners + 1] = v;
 							end
 						end
-						player:EmitSound("warhorns/deathwhistle"..math.random(3,4)..".mp3", 100, math.random(98, 102));
+
+						netstream.Start(listeners, "WarhornOrDeathWhistleSound", player, "warhorns/deathwhistle"..math.random(3,4)..".mp3", math.random(98, 102));
 					end;
 				else
 					Schema:EasyText(player, "peru", "You are not the correct faction to do this!");


### PR DESCRIPTION
On shitty HL2RP servers, you can say "/w Strider". Everyone will hear the sound, but no one will actually see your emote. My commits aim to fix same kind of problem. I think there can only be ONE way to get info about warcries/warhorns/death whistles. And because we can't properly rely on sound traveling logic when dealing with messages in chat, it is better to use message radius to determine whether or not player can hear sound of warcry/warhorn or death whistle